### PR TITLE
fix: prevent duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [setState])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid registering toast listeners more than once by fixing hook dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68920e2d01f48329b79d9f79a17263a1