### PR TITLE
docs: clarify joined profile fields

### DIFF
--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -38,7 +38,7 @@ export interface Request {
   proposito_de_uso?: string;
   validade_uso?: string;
   updated_at: string;
-  // Joined fields from profiles table
+  // Fields from the profiles table. These are populated only when the query joins the profiles table explicitly.
   solicitante_name?: string;
   responsavel_name?: string;
   curador_name?: string;


### PR DESCRIPTION
## Summary
- clarify that joined profile fields are populated only when explicitly joining profiles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68921011bb708329b8bfeb3aa3e42079