### PR TITLE
feat: persist chat sessions and integrate LLM

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,76 @@ export type Database = {
   }
   public: {
     Tables: {
+      chat_messages: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          sender: string
+          session_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: string
+          sender: string
+          session_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          sender?: string
+          session_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_messages_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "chat_sessions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chat_sessions: {
+        Row: {
+          created_at: string
+          id: string
+          last_message_at: string
+          request_id: string | null
+          status: string
+          title: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          last_message_at?: string
+          request_id?: string | null
+          status?: string
+          title: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          last_message_at?: string
+          request_id?: string | null
+          status?: string
+          title?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_sessions_request_id_fkey"
+            columns: ["request_id"]
+            isOneToOne: false
+            referencedRelation: "requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           avatar_url: string | null

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,27 @@
+export type LLMMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export async function sendChatMessage(messages: LLMMessage[]): Promise<string> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText);
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content?.trim() || '';
+}

--- a/supabase/migrations/20250805141700_add_chat_tables.sql
+++ b/supabase/migrations/20250805141700_add_chat_tables.sql
@@ -1,0 +1,55 @@
+-- Create chat sessions and messages tables
+CREATE TABLE public.chat_sessions (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  last_message_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  request_id UUID REFERENCES public.requests(id),
+  status TEXT NOT NULL DEFAULT 'active'
+);
+
+CREATE TABLE public.chat_messages (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  session_id UUID NOT NULL REFERENCES public.chat_sessions(id) ON DELETE CASCADE,
+  sender TEXT NOT NULL CHECK (sender IN ('user','assistant')),
+  content TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.chat_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_messages ENABLE ROW LEVEL SECURITY;
+
+-- Policies for chat_sessions
+CREATE POLICY "Users view their own sessions"
+  ON public.chat_sessions
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users insert their own sessions"
+  ON public.chat_sessions
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users update their own sessions"
+  ON public.chat_sessions
+  FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Policies for chat_messages
+CREATE POLICY "Users view messages in their sessions"
+  ON public.chat_messages
+  FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.chat_sessions s
+    WHERE s.id = session_id AND s.user_id = auth.uid()
+  ));
+
+CREATE POLICY "Users insert messages in their sessions"
+  ON public.chat_messages
+  FOR INSERT
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.chat_sessions s
+    WHERE s.id = session_id AND s.user_id = auth.uid()
+  ));


### PR DESCRIPTION
## Summary
- persist chat sessions and messages in Supabase
- connect data assistant chat to LLM using system prompt
- add helper for OpenAI calls and chat database schema

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689211db45b08329b921b051d671619a