### PR TITLE
Add encrypted OpenAI key management and fix request fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.3.0",
         "input-otp": "^1.2.4",
@@ -4452,6 +4453,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import DataAssistantWithSidebar from "./pages/DataAssistantWithSidebar";
 import MyRequests from "./pages/MyRequests";
+import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 import { AuthProvider } from "@/contexts/AuthContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
@@ -38,13 +39,21 @@ const App = () => (
                 </ProtectedRoute>
               } 
             />
-            <Route 
-              path="/my-requests" 
+            <Route
+              path="/my-requests"
               element={
                 <ProtectedRoute>
                   <MyRequests />
                 </ProtectedRoute>
-              } 
+              }
+            />
+            <Route
+              path="/profile"
+              element={
+                <ProtectedRoute>
+                  <Profile />
+                </ProtectedRoute>
+              }
             />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/components/layout/UserDropdown.tsx
+++ b/src/components/layout/UserDropdown.tsx
@@ -4,9 +4,11 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel,
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { User, Settings, LogOut, Bell, Shield } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 
 export function UserDropdown() {
   const { user, signOut } = useAuth();
+  const navigate = useNavigate();
 
   const getUserInitials = () => {
     if (user?.user_metadata?.display_name) {
@@ -48,7 +50,7 @@ export function UserDropdown() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem className="cursor-pointer">
+        <DropdownMenuItem className="cursor-pointer" onClick={() => navigate('/profile')}>
           <User className="mr-2 h-4 w-4" />
           Meu Perfil
         </DropdownMenuItem>

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
+import type { TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
 
 export interface Request {
   id: string;
@@ -72,7 +73,12 @@ export interface RequestComment {
   user_name?: string;
 }
 
-export const useRequests = () => {
+interface UseRequestsOptions {
+  autoFetch?: boolean;
+}
+
+export const useRequests = (options: UseRequestsOptions = {}) => {
+  const { autoFetch = true } = options;
   const [requests, setRequests] = useState<Request[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -163,7 +169,7 @@ export const useRequests = () => {
           classificacao_dado: requestData.classificacao_dado || 'nao_sensivel',
           estimativa_entrega: requestData.estimativa_entrega,
           proposito_de_uso: requestData.proposito_de_uso
-        } as any)
+        } as TablesInsert<'requests'>)
         .select('*')
         .single();
 
@@ -192,7 +198,7 @@ export const useRequests = () => {
     try {
       const { data, error } = await supabase
         .from('requests')
-        .update(updates as any)
+        .update(updates as TablesUpdate<'requests'>)
         .eq('id', id)
         .select('*')
         .single();
@@ -254,10 +260,10 @@ export const useRequests = () => {
   };
 
   useEffect(() => {
-    if (user) {
+    if (autoFetch && user) {
       fetchUserRequests();
     }
-  }, [user]);
+  }, [user, autoFetch]);
 
   return {
     requests,

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -3,8 +3,13 @@ export type LLMMessage = {
   content: string;
 };
 
+import { getApiKey } from './secureStorage';
+
 export async function sendChatMessage(messages: LLMMessage[]): Promise<string> {
-  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    throw new Error('API key not configured');
+  }
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {

--- a/src/lib/secureStorage.ts
+++ b/src/lib/secureStorage.ts
@@ -1,0 +1,25 @@
+import CryptoJS from 'crypto-js';
+
+const STORAGE_KEY = 'openai_api_key';
+const SECRET = import.meta.env.VITE_API_KEY_SECRET || 'default_secret';
+
+export function saveApiKey(apiKey: string) {
+  const encrypted = CryptoJS.AES.encrypt(apiKey, SECRET).toString();
+  localStorage.setItem(STORAGE_KEY, encrypted);
+}
+
+export function getApiKey(): string | null {
+  const encrypted = localStorage.getItem(STORAGE_KEY);
+  if (!encrypted) return null;
+  try {
+    const bytes = CryptoJS.AES.decrypt(encrypted, SECRET);
+    const decrypted = bytes.toString(CryptoJS.enc.Utf8);
+    return decrypted || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+export function clearApiKey() {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/pages/DataAssistantWithSidebar.tsx
+++ b/src/pages/DataAssistantWithSidebar.tsx
@@ -9,6 +9,7 @@ import { ChatSidebar } from "@/components/layout/ChatSidebar";
 import { useChat } from "@/contexts/ChatContext";
 import { useRequests } from "@/hooks/useRequests";
 import { sendChatMessage } from "@/lib/llm";
+import type { Message as ChatMessage } from "@/contexts/ChatContext";
 
 interface DataSuggestion {
   name: string;
@@ -77,7 +78,7 @@ const DataAssistantWithSidebar = () => {
     linkSessionToRequest,
     getSessionByRequest 
   } = useChat();
-  const { createRequest } = useRequests();
+  const { createRequest } = useRequests({ autoFetch: false });
   
   const [currentStep, setCurrentStep] = useState<ConversationStep>('welcome');
   const [inputValue, setInputValue] = useState('');
@@ -148,7 +149,7 @@ const DataAssistantWithSidebar = () => {
     scrollToBottom();
   }, [currentSession?.messages]);
 
-  const addMessage = (message: any) => {
+  const addMessage = (message: Omit<ChatMessage, 'id' | 'timestamp'>) => {
     if (currentSession) {
       addMessageToSession(currentSession.id, message);
     }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft } from "lucide-react";
+import { saveApiKey, getApiKey, clearApiKey } from "@/lib/secureStorage";
+
+const Profile = () => {
+  const navigate = useNavigate();
+  const [apiKey, setApiKey] = useState("");
+  const [hasKey, setHasKey] = useState(false);
+
+  useEffect(() => {
+    const existing = getApiKey();
+    setHasKey(!!existing);
+  }, []);
+
+  const handleSave = () => {
+    if (!apiKey) return;
+    saveApiKey(apiKey);
+    setApiKey("");
+    setHasKey(true);
+  };
+
+  const handleRemove = () => {
+    clearApiKey();
+    setHasKey(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col pb-16 md:pb-0">
+      <div className="flex items-center p-3 sm:p-4 border-b bg-card">
+        <Button variant="ghost" size="icon" className="mr-2" onClick={() => navigate(-1)}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <h1 className="text-lg sm:text-xl font-bold">Meu Perfil</h1>
+      </div>
+
+      <div className="flex-1 p-4 flex justify-center items-start">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>OpenAI API Key</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {hasKey && (
+              <p className="text-sm text-muted-foreground">
+                Uma chave de API já está configurada.
+              </p>
+            )}
+            <Input
+              type="password"
+              placeholder="Insira sua chave de API"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <Button onClick={handleSave} disabled={!apiKey}>Salvar</Button>
+              {hasKey && (
+                <Button variant="outline" onClick={handleRemove}>
+                  Remover
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
## Summary
- allow useRequests to skip automatic fetch and avoid toast in data assistant
- enable LLM calls using encrypted API key stored in user profile
- add profile page and menu link for managing OpenAI key

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint src/lib/secureStorage.ts src/lib/llm.ts src/hooks/useRequests.ts src/pages/Profile.tsx src/pages/DataAssistantWithSidebar.tsx src/components/layout/UserDropdown.tsx src/App.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68921549edac83298e50fdf299186bd7