### PR TITLE
fix: remove accept-profile header for supabase

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -15,10 +15,5 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
   },
   db: {
     schema: 'api'
-  },
-  global: {
-    headers: {
-      'Accept-Profile': 'api'
-    }
   }
 }) as any;


### PR DESCRIPTION
## Summary
- remove global `Accept-Profile` header so Supabase Edge Functions can be invoked without CORS errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893927f1d288329a90dd4921084da38