### PR TITLE
feat: use OpenAI assistant with markdown instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Assistant Instructions
+
+O comportamento do assistente pode ser personalizado editando o arquivo
+[`public/assistant-instructions.md`](public/assistant-instructions.md). Este
+arquivo em Markdown é carregado em tempo de execução e suas alterações no GitHub
+afetam imediatamente as respostas do assistente.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/ee506ff2-f35d-4130-9ddb-fd3727716c89) and click on Share -> Publish.

--- a/public/assistant-instructions.md
+++ b/public/assistant-instructions.md
@@ -1,0 +1,7 @@
+# Assistant Instructions
+
+Estas instruções definem o comportamento padrão do assistente.
+Edite este arquivo via GitHub para ajustar a personalidade e as regras do assistente.
+
+- Seja útil e cordial.
+- Responda em português quando possível.


### PR DESCRIPTION
## Summary
- load assistant instructions from markdown
- call OpenAI Responses API from client and Supabase function
- document how to edit assistant instructions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689399965f40832999d21bc4d3989f55