### PR TITLE
feat: use OpenAI assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
-## Assistant Instructions
+## Assistant Configuration
 
-O comportamento do assistente pode ser personalizado editando o arquivo
-[`public/assistant-instructions.md`](public/assistant-instructions.md). Este
-arquivo em Markdown é carregado em tempo de execução e suas alterações no GitHub
-afetam imediatamente as respostas do assistente.
+O comportamento do assistente agora é definido através de um Assistente criado
+no painel da OpenAI. Configure o seu assistente e informe o seu identificador
+nas variáveis de ambiente `VITE_ASSISTANT_ID` (aplicação web) e `ASSISTANT_ID`
+(função do Supabase). O arquivo
+[`public/assistant-instructions.md`](public/assistant-instructions.md) não é
+mais utilizado.
 
 ## How can I deploy this project?
 

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -27,16 +27,10 @@ export async function sendChatMessage(messages: LLMMessage[]): Promise<string> {
   try {
     console.log('sendChatMessage: retrieving API key...');
     const apiKey = await getOpenAIApiKey();
-
-    console.log('sendChatMessage: loading assistant instructions...');
-    const instructionsUrl =
-      import.meta.env.VITE_ASSISTANT_INSTRUCTIONS_URL ||
-      '/assistant-instructions.md';
-    const instructionsRes = await fetch(instructionsUrl);
-    if (!instructionsRes.ok) {
-      throw new Error('Failed to load assistant instructions');
+    const assistantId = import.meta.env.VITE_ASSISTANT_ID;
+    if (!assistantId) {
+      throw new Error('Assistant ID not configured');
     }
-    const instructions = await instructionsRes.text();
 
     console.log('sendChatMessage: calling OpenAI responses API...');
     const response = await fetch('https://api.openai.com/v1/responses', {
@@ -46,9 +40,8 @@ export async function sendChatMessage(messages: LLMMessage[]): Promise<string> {
         'Authorization': `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4.1-mini',
+        assistant_id: assistantId,
         input: messages,
-        instructions,
         max_output_tokens: 1000,
         temperature: 0.7,
       }),

--- a/supabase/functions/chat-openai/index.ts
+++ b/supabase/functions/chat-openai/index.ts
@@ -89,18 +89,16 @@ serve(async (req) => {
       );
     }
 
-    console.log('Loading assistant instructions...');
-    const instructionsUrl =
-      Deno.env.get('ASSISTANT_INSTRUCTIONS_URL') ||
-      'https://raw.githubusercontent.com/OWNER/REPO/main/public/assistant-instructions.md';
-    let instructions = '';
-    try {
-      const instructionsRes = await fetch(instructionsUrl);
-      if (instructionsRes.ok) {
-        instructions = await instructionsRes.text();
-      }
-    } catch (e) {
-      console.error('Failed to load instructions:', e);
+    const assistantId = Deno.env.get('ASSISTANT_ID');
+    if (!assistantId) {
+      console.error('Assistant ID not configured');
+      return new Response(
+        JSON.stringify({ error: 'Assistant ID not configured' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      );
     }
 
     console.log('Making OpenAI responses API call...');
@@ -113,9 +111,8 @@ serve(async (req) => {
         'Authorization': `Bearer ${openaiApiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4.1-mini',
+        assistant_id: assistantId,
         input: messages,
-        instructions,
         max_output_tokens: maxTokens,
         temperature: 0.7,
       }),


### PR DESCRIPTION
## Summary
- use assistant_id for OpenAI chat requests
- document assistant configuration env vars

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939bc58d1883299d16e311d2bfeb94