### PR TITLE
feat: pass assistant id from client

### DIFF
--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -10,8 +10,14 @@ export async function sendChatMessage(messages: LLMMessage[]): Promise<string> {
 
   try {
     console.log('sendChatMessage: invoking chat-openai function...');
+
+    const assistantId = import.meta.env.VITE_ASSISTANT_ID;
+    if (!assistantId) {
+      throw new Error('Assistant ID not configured');
+    }
+
     const { data, error } = await supabase.functions.invoke('chat-openai', {
-      body: { messages }
+      body: { messages, assistantId }
     });
 
     if (error) {

--- a/supabase/functions/chat-openai/index.ts
+++ b/supabase/functions/chat-openai/index.ts
@@ -15,6 +15,7 @@ interface ChatMessage {
 
 interface ChatRequest {
   messages: ChatMessage[];
+  assistantId?: string;
   maxTokens?: number;
 }
 
@@ -64,7 +65,7 @@ serve(async (req) => {
     console.log('Authenticated user:', user.id);
 
     // Obter dados da requisição
-    const { messages, maxTokens = 1000 }: ChatRequest = await req.json();
+    const { messages, assistantId: bodyAssistantId, maxTokens = 1000 }: ChatRequest = await req.json();
     
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       return new Response(
@@ -76,20 +77,20 @@ serve(async (req) => {
       );
     }
 
-    // Obter chave da OpenAI do ambiente
+    // Obter chave e ID do assistente
     const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
     if (!openaiApiKey) {
       console.error('OpenAI API key not configured');
       return new Response(
         JSON.stringify({ error: 'OpenAI API key not configured' }),
-        { 
-          status: 500, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         }
       );
     }
 
-    const assistantId = Deno.env.get('ASSISTANT_ID');
+    const assistantId = bodyAssistantId || Deno.env.get('ASSISTANT_ID');
     if (!assistantId) {
       console.error('Assistant ID not configured');
       return new Response(


### PR DESCRIPTION
## Summary
- provide assistant id to chat-openai invocation from client
- allow edge function to accept assistant id in request body

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a641e5e883299ad338b3d56faa96