### PR TITLE
fix: parse OpenAI response correctly

### DIFF
--- a/supabase/functions/chat-openai/index.ts
+++ b/supabase/functions/chat-openai/index.ts
@@ -135,7 +135,11 @@ serve(async (req) => {
     }
 
     const data = await response.json();
-    const content = data?.output?.[0]?.content?.[0]?.text?.value?.trim();
+    // Try multiple shapes for the response content to avoid runtime errors
+    const content =
+      data?.output_text?.trim() ??
+      data?.output?.[0]?.content?.[0]?.text?.value?.trim() ??
+      data?.output?.[0]?.content?.[0]?.text?.trim();
 
     if (!content) {
       console.error('OpenAI response missing text content', data);


### PR DESCRIPTION
## Summary
- guard chat-openai function against varying OpenAI response shapes to avoid 500 errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a803987c8329bc9a77c226a837d8