### PR TITLE
fix: retrieve OpenAI key via get-secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ painel da OpenAI. As instruções do Assistente ficam versionadas em
 [`public/assistant-instructions.md`](public/assistant-instructions.md).
 
 Use o script abaixo para sincronizar essas instruções com a OpenAI e salvar o
-identificador do assistente nas variáveis de ambiente `VITE_ASSISTANT_ID` e
-`ASSISTANT_ID`:
+identificador do assistente na variável de ambiente `ASSISTANT_ID`:
 
 ```sh
 npm run sync-assistant
@@ -78,6 +77,10 @@ Certifique-se de definir a variável `OPENAI_API_KEY` e, opcionalmente,
 `OPENAI_ASSISTANT_MODEL` antes de executar o script. Caso não exista um
 assistente ainda, um novo será criado usando o modelo informado (padrão
 `gpt-4o-mini`).
+
+No aplicativo, o identificador do assistente é recuperado dinamicamente através
+da function `get-assistant-discovery`, portanto nenhuma variável de ambiente é
+necessária para isso.
 
 ## How can I deploy this project?
 

--- a/scripts/sync-assistant.ts
+++ b/scripts/sync-assistant.ts
@@ -52,9 +52,8 @@ async function main() {
     if (fs.existsSync(envPath)) {
       envContent = fs.readFileSync(envPath, 'utf8');
     }
-    envContent = envContent.replace(/ASSISTANT_ID=.*/g, '')
-                           .replace(/VITE_ASSISTANT_ID=.*/g, '');
-    envContent += `\nASSISTANT_ID=${assistantId}\nVITE_ASSISTANT_ID=${assistantId}\n`;
+    envContent = envContent.replace(/ASSISTANT_ID=.*/g, '');
+    envContent += `\nASSISTANT_ID=${assistantId}\n`;
     fs.writeFileSync(envPath, envContent.trim() + '\n');
     console.log('Assistant created. ID stored in .env:', assistantId);
   }


### PR DESCRIPTION
## Summary
- fetch OpenAI API key using Supabase `get-secret` function
- dynamically discover assistant ID through Supabase `get-assistant-discovery`
- remove now-unused `VITE_ASSISTANT_ID` environment variable references

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893b0b83bc88329a2a192ea5e97ab1b