### PR TITLE
Refactor auth provider usage and stabilize request comments hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import DataAssistantWithSidebar from "./pages/DataAssistantWithSidebar";
 import MyRequests from "./pages/MyRequests";
 import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
-import { AuthProvider } from "@/contexts/AuthContext";
 import ProtectedRoute from "@/components/ProtectedRoute";
 
 const queryClient = new QueryClient();
@@ -17,11 +16,10 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <AuthProvider>
-        <Toaster />
-        <Sonner />
-        <BrowserRouter>
-          <Routes>
+      <Toaster />
+      <Sonner />
+      <BrowserRouter>
+        <Routes>
             <Route 
               path="/" 
               element={
@@ -59,7 +57,6 @@ const App = () => (
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>
-      </AuthProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -285,7 +285,7 @@ export const useRequestComments = (requestId: string) => {
   const [loading, setLoading] = useState(true);
   const { user } = useAuth();
 
-  const fetchComments = async () => {
+  const fetchComments = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -303,7 +303,7 @@ export const useRequestComments = (requestId: string) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [requestId]);
 
   const addComment = async (comentario: string) => {
     if (!user) return null;
@@ -338,7 +338,7 @@ export const useRequestComments = (requestId: string) => {
     if (requestId) {
       fetchComments();
     }
-  }, [requestId]);
+  }, [requestId, fetchComments]);
 
   return {
     comments,


### PR DESCRIPTION
## Summary
- remove duplicate AuthProvider wrapper from App
- stabilize request comment hook dependency management

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893bdf0ccc083299cceeebe66a6388e