### PR TITLE
feat: handle async session operations

### DIFF
--- a/src/pages/DataAssistantWithSidebar.tsx
+++ b/src/pages/DataAssistantWithSidebar.tsx
@@ -61,7 +61,12 @@ const DataAssistantWithSidebar = () => {
   };
 
   const handleNewChat = async () => {
-    const sessionId = createNewSession('Nova descoberta');
+    try {
+      await createNewSession('Nova descoberta');
+    } catch (e) {
+      console.error('Erro ao criar sessão:', e);
+      return;
+    }
 
     try {
       const response = await sendChatMessage([


### PR DESCRIPTION
## Summary
- make session management functions async and toast errors
- await createNewSession calls in chat page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893c0f1b3b8832986ff1f2a3760afb6