### PR TITLE
fix: ensure supabase client uses database types

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -8,7 +8,9 @@ const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+// Create a typed Supabase client using the generated `Database` types.
+// This ensures all queries are fully type-safe throughout the project.
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     storage: localStorage,
     persistSession: true,


### PR DESCRIPTION
## Summary
- ensure Supabase client is typed with generated Database definitions for safe queries

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c48f166c8329b33dac8a98896ce2