### PR TITLE
chore: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ ALLOWED_ORIGINS=https://exemplo.com,https://app.exemplo.com
 
 ## How can I deploy this project?
 
-Simply open [Lovable](https://lovable.dev/projects/ee506ff2-f35d-4130-9ddb-fd3727716c89) and click on Share -> Publish.
+This repository includes a GitHub Actions workflow that builds the project and publishes the `dist` directory to GitHub Pages. On each push to the `main` branch:
+
+1. GitHub installs dependencies and runs `npm run build`.
+2. The generated `dist` folder is uploaded and deployed to GitHub Pages.
+
+To use it, make sure the repository has the secrets `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` configured with your Supabase credentials.
+
+You can still deploy via [Lovable](https://lovable.dev/projects/ee506ff2-f35d-4130-9ddb-fd3727716c89) by clicking **Share → Publish** if you prefer.
 
 ## Can I connect a custom domain to my Lovable project?
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy to GitHub Pages
- document Pages deployment and required secrets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689be65538108329aa28718a4f723e8d